### PR TITLE
Big Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Additional v2 inspired from [ConfuserEx-Additions](https://github.com/Lekysha/Co
 
 
 
+
 ## ConfuserEx-Additions-v2:
 
 ##### - AntiDe4dot: 


### PR DESCRIPTION
After analyzing this repository deeply, I came to the conclusion that these protections are either skidded/taken from other private protectors which where leaked around a month ago or taken from open-source projects. An argument to support this is that you disabled issues knowing that people would notice that you skidded.

You may ask how I came to this conclusion ?

Well here is how:
If you look at some of the protections you can notice that they override a property with the name “Author”, this property does not exist in standard ConfuserEx. Another fact is that some of these protections are skidded from a old ConfuserEx mod I developed a long time ago. There have only been small changes you applied. Also from looking at these protections most of them won’t even work in the standard ConfuserEx.

Next time don’t skid protections and write your own stuff.